### PR TITLE
Revert "updates: use top-level since nix-update stopped handling paths"

### DIFF
--- a/overlays/extra-packages.nix
+++ b/overlays/extra-packages.nix
@@ -46,7 +46,7 @@ in
   }).overrideAttrs (_: {
     passthru = forAttrNames extra-packages (name:
       package-updater name {
-        package = name;
+        package = "extra-packages.${name}";
       }
     );
   });


### PR DESCRIPTION
This reverts commit 77690eedd4c95aca6af50ff70a0996d01518289a.